### PR TITLE
Fixing up radare2's cloud Dockerfile for an IPFS test

### DIFF
--- a/http-cloud.radare.org/Dockerfile
+++ b/http-cloud.radare.org/Dockerfile
@@ -15,7 +15,7 @@ ADD www /www
 RUN type setcap
 
 RUN rm -rf /www/enyo /www/p /www/m /www/t && \
-    cd radare2/shlr/www && cp -rf enyo m p t /www/
+    cd radare2/shlr/www && cp -rf enyo m t /www/
 
 EXPOSE 80
 ENTRYPOINT bash -c "make -C /src SUDO="


### PR DESCRIPTION
Hi @radare,

I'm fixing stuff as I go over here... found this while building:

```
Step 10 : RUN rm -rf /www/enyo /www/p /www/m /www/t &&     cd radare2/shlr/www && cp -rf enyo m p t /www/
 ---> Running in 59983093c97a
cp: cannot stat 'p': No such file or directory
```

And this while trying to bring it up/running:

```
$ alias dki
alias dki='docker run -t -i -P'
$ dki 8874e3a00bd5
make: Entering directory '/src'
echo findus
findus
mkdir -p /opt/sandbox
sleep 5 && curl localhost:8080/cmd/aa &
sh start-r2.sh
Running r2
running r2
sh: 1: cannot create /opt/sandbox/pid: Permission denied
sh: 1: cannot create /opt/sandbox/log: Permission denied
make: *** [Makefile:7: all] Error 1
make: Leaving directory '/src'
```
